### PR TITLE
Allow empty database name in OpenDBI method

### DIFF
--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -289,8 +289,9 @@ func (txn *Txn) renew() error {
 	return operrno("mdb_txn_renew", ret)
 }
 
-// OpenDBI opens a named database in the environment.  An error is returned if
-// name is empty.  The DBI returned by OpenDBI can be used in other
+// OpenDBI opens a database in the environment. If only a single database is
+// needed in the environment, the name value can be an empty string.
+// The DBI returned by OpenDBI can be used in other
 // transactions but not before Txn has terminated.
 //
 // OpenDBI can only be called after env.SetMaxDBs() has been called to set the
@@ -302,8 +303,14 @@ func (txn *Txn) renew() error {
 //
 // See mdb_dbi_open.
 func (txn *Txn) OpenDBI(name string, flags uint) (DBI, error) {
+	var dbi DBI
+	var err error
+	if name == "" {
+		dbi, err = txn.openDBI(nil, flags)
+		return dbi, err
+	}
 	cname := C.CString(name)
-	dbi, err := txn.openDBI(cname, flags)
+	dbi, err = txn.openDBI(cname, flags)
 	C.free(unsafe.Pointer(cname))
 	return dbi, err
 }

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -423,19 +423,6 @@ func TestTxn_Put_overwrite(t *testing.T) {
 	}
 }
 
-func TestTxn_OpenDBI_emptyName(t *testing.T) {
-	env := setup(t)
-	defer clean(env, t)
-
-	err := env.View(func(txn *Txn) (err error) {
-		_, err = txn.OpenDBI("", 0)
-		return err
-	})
-	if !IsErrno(err, BadValSize) {
-		t.Errorf("mdb_dbi_open: %v", err)
-	}
-}
-
 func TestTxn_OpenDBI_zero(t *testing.T) {
 	env := setup(t)
 	defer clean(env, t)


### PR DESCRIPTION
Allow to the name value OpenDBI method as an empty string.
From lmdb documentation [doc](http://www.lmdb.tech/doc/group__internal.html#gac08cad5b096925642ca359a6d6f0562a) name can be empty  "If only a single database is needed in the environment, this value may be NULL."